### PR TITLE
fix(graphite): Convert glob patterns to regex to fix invalid match error

### DIFF
--- a/graphite/graphite_mapping.conf
+++ b/graphite/graphite_mapping.conf
@@ -3,6 +3,10 @@
 #
 # TrueNAS sends metrics in format: servers.<hostname>.<category>.<metric>
 # We transform these into: truenas_<category>_<metric>{host="<hostname>"}
+#
+# NOTE: All patterns use regex matching (match_type: "regex") because
+# graphite_exporter's glob matcher doesn't support substring wildcards
+# like "prefix-*" or "*-suffix". See: github.com/prometheus/graphite_exporter/issues/241
 
 mappings:
   # ==========================================================================
@@ -80,7 +84,9 @@ mappings:
   # ==========================================================================
 
   # CPU usage per core
-  - match: "servers.*.cpu-*.cpu-*"
+  # Example: servers.mynas.cpu-0.cpu-idle -> cpu_usage{host="mynas",cpu="0",type="idle"}
+  - match: 'servers\.([^.]+)\.cpu-([^.]+)\.cpu-([^.]+)'
+    match_type: "regex"
     name: "cpu_usage"
     labels:
       host: "$1"
@@ -88,7 +94,9 @@ mappings:
       type: "$3"
 
   # CPU temperature per core
-  - match: "servers.*.cputemp-*.temperature"
+  # Example: servers.mynas.cputemp-0.temperature -> cpu_temperature{host="mynas",cpu="0"}
+  - match: 'servers\.([^.]+)\.cputemp-([^.]+)\.temperature'
+    match_type: "regex"
     name: "cpu_temperature"
     labels:
       host: "$1"
@@ -98,7 +106,9 @@ mappings:
   # System Load
   # ==========================================================================
 
-  - match: "servers.*.load.load.*"
+  # Example: servers.mynas.load.load.shortterm -> system_load{host="mynas",kind="shortterm"}
+  - match: 'servers\.([^.]+)\.load\.load\.([^.]+)'
+    match_type: "regex"
     name: "system_load"
     labels:
       host: "$1"
@@ -109,7 +119,9 @@ mappings:
   # ==========================================================================
 
   # General memory stats
-  - match: "servers.*.memory.memory-*"
+  # Example: servers.mynas.memory.memory-used -> memory{host="mynas",type="used"}
+  - match: 'servers\.([^.]+)\.memory\.memory-([^.]+)'
+    match_type: "regex"
     name: "memory"
     labels:
       host: "$1"
@@ -120,7 +132,9 @@ mappings:
   # ==========================================================================
 
   # Disk operations
-  - match: "servers.*.disk-*.disk_ops.*"
+  # Example: servers.mynas.disk-sda.disk_ops.read -> disk_ops{host="mynas",disk="sda",op="read"}
+  - match: 'servers\.([^.]+)\.disk-([^.]+)\.disk_ops\.([^.]+)'
+    match_type: "regex"
     name: "disk_ops"
     labels:
       host: "$1"
@@ -128,7 +142,8 @@ mappings:
       op: "$3"
 
   # Disk I/O throughput
-  - match: "servers.*.disk-*.disk_io_time.*"
+  - match: 'servers\.([^.]+)\.disk-([^.]+)\.disk_io_time\.([^.]+)'
+    match_type: "regex"
     name: "disk_io_time"
     labels:
       host: "$1"
@@ -136,7 +151,8 @@ mappings:
       type: "$3"
 
   # Disk octets (bytes)
-  - match: "servers.*.disk-*.disk_octets.*"
+  - match: 'servers\.([^.]+)\.disk-([^.]+)\.disk_octets\.([^.]+)'
+    match_type: "regex"
     name: "disk_octets"
     labels:
       host: "$1"
@@ -144,7 +160,8 @@ mappings:
       direction: "$3"
 
   # Disk time
-  - match: "servers.*.disk-*.disk_time.*"
+  - match: 'servers\.([^.]+)\.disk-([^.]+)\.disk_time\.([^.]+)'
+    match_type: "regex"
     name: "disk_time"
     labels:
       host: "$1"
@@ -155,7 +172,9 @@ mappings:
   # Disk Temperature
   # ==========================================================================
 
-  - match: "servers.*.disktemp-*.temperature"
+  # Example: servers.mynas.disktemp-serial123.temperature -> disk_temperature{host="mynas",serial="serial123"}
+  - match: 'servers\.([^.]+)\.disktemp-([^.]+)\.temperature'
+    match_type: "regex"
     name: "disk_temperature"
     labels:
       host: "$1"
@@ -166,7 +185,9 @@ mappings:
   # ==========================================================================
 
   # Interface errors
-  - match: "servers.*.interface-*.if_errors.*"
+  # Example: servers.mynas.interface-eth0.if_errors.rx -> interface_errors{host="mynas",interface="eth0",direction="rx"}
+  - match: 'servers\.([^.]+)\.interface-([^.]+)\.if_errors\.([^.]+)'
+    match_type: "regex"
     name: "interface_errors"
     labels:
       host: "$1"
@@ -174,7 +195,8 @@ mappings:
       direction: "$3"
 
   # Interface octets (traffic)
-  - match: "servers.*.interface-*.if_octets.*"
+  - match: 'servers\.([^.]+)\.interface-([^.]+)\.if_octets\.([^.]+)'
+    match_type: "regex"
     name: "interface_octets"
     labels:
       host: "$1"
@@ -182,7 +204,8 @@ mappings:
       direction: "$3"
 
   # Interface packets
-  - match: "servers.*.interface-*.if_packets.*"
+  - match: 'servers\.([^.]+)\.interface-([^.]+)\.if_packets\.([^.]+)'
+    match_type: "regex"
     name: "interface_packets"
     labels:
       host: "$1"
@@ -193,7 +216,9 @@ mappings:
   # System Uptime
   # ==========================================================================
 
-  - match: "servers.*.uptime.uptime"
+  # Example: servers.mynas.uptime.uptime -> uptime{host="mynas"}
+  - match: 'servers\.([^.]+)\.uptime\.uptime'
+    match_type: "regex"
     name: "uptime"
     labels:
       host: "$1"
@@ -202,7 +227,9 @@ mappings:
   # Processes
   # ==========================================================================
 
-  - match: "servers.*.processes.ps_state-*"
+  # Example: servers.mynas.processes.ps_state-running -> processes{host="mynas",state="running"}
+  - match: 'servers\.([^.]+)\.processes\.ps_state-([^.]+)'
+    match_type: "regex"
     name: "processes"
     labels:
       host: "$1"
@@ -212,14 +239,18 @@ mappings:
   # ZFS ARC Metrics
   # ==========================================================================
 
-  - match: "servers.*.zfs_arc.cache_*-*"
+  # Example: servers.mynas.zfs_arc.cache_size-current -> zfs_arc{host="mynas",cache="size",type="current"}
+  - match: 'servers\.([^.]+)\.zfs_arc\.cache_([^-]+)-([^.]+)'
+    match_type: "regex"
     name: "zfs_arc"
     labels:
       host: "$1"
       cache: "$2"
       type: "$3"
 
-  - match: "servers.*.zfs_arc_v2.*.value"
+  # Example: servers.mynas.zfs_arc_v2.hits.value -> zfs_arc_v2{host="mynas",metric="hits"}
+  - match: 'servers\.([^.]+)\.zfs_arc_v2\.([^.]+)\.value'
+    match_type: "regex"
     name: "zfs_arc_v2"
     labels:
       host: "$1"
@@ -230,28 +261,33 @@ mappings:
   # ==========================================================================
 
   # UPS charge
-  - match: "servers.*.nut-*.percent-charge"
+  # Example: servers.mynas.nut-ups1.percent-charge -> ups_charge_percent{host="mynas",ups="ups1"}
+  - match: 'servers\.([^.]+)\.nut-([^.]+)\.percent-charge'
+    match_type: "regex"
     name: "ups_charge_percent"
     labels:
       host: "$1"
       ups: "$2"
 
   # UPS load
-  - match: "servers.*.nut-*.percent-load"
+  - match: 'servers\.([^.]+)\.nut-([^.]+)\.percent-load'
+    match_type: "regex"
     name: "ups_load_percent"
     labels:
       host: "$1"
       ups: "$2"
 
   # UPS runtime
-  - match: "servers.*.nut-*.timeleft-battery"
+  - match: 'servers\.([^.]+)\.nut-([^.]+)\.timeleft-battery'
+    match_type: "regex"
     name: "ups_runtime_seconds"
     labels:
       host: "$1"
       ups: "$2"
 
   # UPS voltage
-  - match: "servers.*.nut-*.voltage-*"
+  - match: 'servers\.([^.]+)\.nut-([^.]+)\.voltage-([^.]+)'
+    match_type: "regex"
     name: "ups_voltage"
     labels:
       host: "$1"
@@ -259,7 +295,8 @@ mappings:
       type: "$3"
 
   # UPS frequency
-  - match: "servers.*.nut-*.frequency-*"
+  - match: 'servers\.([^.]+)\.nut-([^.]+)\.frequency-([^.]+)'
+    match_type: "regex"
     name: "ups_frequency"
     labels:
       host: "$1"
@@ -267,7 +304,8 @@ mappings:
       type: "$3"
 
   # UPS temperature
-  - match: "servers.*.nut-*.temperature"
+  - match: 'servers\.([^.]+)\.nut-([^.]+)\.temperature'
+    match_type: "regex"
     name: "ups_temperature"
     labels:
       host: "$1"
@@ -278,21 +316,26 @@ mappings:
   # ==========================================================================
 
   # Memory info (TrueNAS specific format)
-  - match: "servers.*.truenas-meminfo-*.gauge"
+  # Example: servers.mynas.truenas-meminfo-MemTotal.gauge -> truenas_meminfo{host="mynas",type="MemTotal"}
+  - match: 'servers\.([^.]+)\.truenas-meminfo-([^.]+)\.gauge'
+    match_type: "regex"
     name: "truenas_meminfo"
     labels:
       host: "$1"
       type: "$2"
 
   # Cgroup CPU usage
-  - match: "servers.*.truenas-cgroup_cpu_percent-*.percent"
+  # Example: servers.mynas.truenas-cgroup_cpu_percent-docker_app.percent -> cgroup_cpu_percent{host="mynas",cgroup="docker_app"}
+  - match: 'servers\.([^.]+)\.truenas-cgroup_cpu_percent-([^.]+)\.percent'
+    match_type: "regex"
     name: "cgroup_cpu_percent"
     labels:
       host: "$1"
       cgroup: "$2"
 
   # Cgroup memory
-  - match: "servers.*.truenas-cgroup_mem-*.gauge"
+  - match: 'servers\.([^.]+)\.truenas-cgroup_mem-([^.]+)\.gauge'
+    match_type: "regex"
     name: "cgroup_memory"
     labels:
       host: "$1"


### PR DESCRIPTION
## Summary

- Converts all glob patterns with substring wildcards (e.g., `cpu-*`, `disk-*`) to regex patterns with `match_type: "regex"`
- The graphite_exporter's glob matcher only supports full segment wildcards, not substring patterns like `prefix-*`
- Adds explanatory comments with example transformations for each metric type

## Root Cause

The graphite_exporter glob matcher doesn't support patterns like `servers.*.cpu-*.cpu-*` because `cpu-*` is a substring wildcard (prefix + wildcard), not a full segment wildcard. This is a known limitation documented in [prometheus/graphite_exporter#241](https://github.com/prometheus/graphite_exporter/issues/241).

## Changes

All non-drop-rule patterns converted from glob to regex:
- `servers.*.cpu-*.cpu-*` → `servers\.([^.]+)\.cpu-([^.]+)\.cpu-([^.]+)`
- Similar conversions for: `cputemp-*`, `memory-*`, `disk-*`, `disktemp-*`, `interface-*`, `ps_state-*`, `cache_*-*`, `nut-*`, `truenas-meminfo-*`, `truenas-cgroup_*`

## Test plan

- [ ] Rebuild Docker image with updated config
- [ ] Verify graphite_exporter starts without "invalid match" error
- [ ] Confirm metrics are correctly mapped and labeled

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)